### PR TITLE
Bug Fix for ymd_hms() call embedded in midnight_to_midnight

### DIFF
--- a/R/midnight_to_midnight.R
+++ b/R/midnight_to_midnight.R
@@ -42,7 +42,9 @@ midnight_to_midnight <- function(acc, acc_ts){
   ## Added 2021-01-06 as protective measure in case one fails to submit
   ## acc_ts as lubridate::ymd_hms()-generated is.POSIXct
   ## (note: base::as.POSIXct()-generated IS NOT OK!)
-  acc_ts <- lubridate::ymd_hms(acc_ts)
+  if(class(acc_ts)[1]!= "POSIXct"){
+    acc_ts <- lubridate::ymd_hms(acc_ts)
+  }
 
   ## Define day-specific minute for each observation
   obs_df <- data.frame(acc = acc, acc_ts = acc_ts, stringsAsFactors = FALSE)

--- a/README.Rmd
+++ b/README.Rmd
@@ -78,7 +78,7 @@ The data columns are:
 ## Plot activity counts
 ## Format timestamp data column from character to POSIXct object
 ggplot(dat, aes(x = ymd_hms(timestamp), y = vectormagnitude)) + 
-  geom_line(size = 0.3, alpha = 0.8) + 
+  geom_line(linewidth = 0.3, alpha = 0.8) + 
   labs(x = "Time", y = "Activity counts") + 
   theme_gray(base_size = 10) + 
   scale_x_datetime(date_breaks = "1 day", date_labels = "%b %d")


### PR DESCRIPTION
An example
```
fpath <- system.file("extdata", extdata_fnames[1], package = "arctools")
dat <- read_csv(fpath, skip = 10,col_types = "iiiic")
rbind(head(dat, 3), tail(dat, 3))

### passing a posix timestamp into midnight_to_midnight is bugged
acc <- dat$vectormagnitude
acc_ts <- ymd_hms(dat$timestamp)
acc2 <- midnight_to_midnight(acc, acc_ts)
plot(is.na(acc2))
plot(is.na(acc))

### the bug can be explained by the redundant call to ymd_hms within m2m
acc_ts2 <- ymd_hms(acc_ts)
plot(is.na(acc_ts))
plot(is.na(acc_ts2))
```